### PR TITLE
pass SerialClass to rfxcom.transport.base.BaseTransport

### DIFF
--- a/rfxcom/transport/asyncio.py
+++ b/rfxcom/transport/asyncio.py
@@ -13,7 +13,8 @@ class AsyncioTransport(BaseTransport):
     def __init__(self, device, loop, callback=None, callbacks=None,
                  SerialClass=None):
 
-        super().__init__(device, callback=callback, callbacks=callbacks)
+        super().__init__(device, callback=callback, callbacks=callbacks,
+                         SerialClass=SerialClass)
 
         self.loop = loop
         self.write_queue = []


### PR DESCRIPTION
BaseTransport uses SerialClass if passed, but child class is not passing it to its parent constructor.
