### PR TITLE
call_later should call write() not its result

### DIFF
--- a/rfxcom/transport/asyncio.py
+++ b/rfxcom/transport/asyncio.py
@@ -48,7 +48,7 @@ class AsyncioTransport(BaseTransport):
         super().write(RESET_PACKET)
 
         self.log.info("Write the status packet in 0.1 seconds. (blocking)")
-        self.loop.call_later(0.1, super().write(STATUS_PACKET))
+        self.loop.call_later(0.1, super().write, STATUS_PACKET)
 
         self.log.info("Adding the queued writer in 0.2 seconds.")
         self.loop.call_later(

--- a/tests/transport/test_asyncio.py
+++ b/tests/transport/test_asyncio.py
@@ -1,24 +1,28 @@
-from asyncio import get_event_loop
 from unittest import TestCase, mock
 
 from rfxcom.transport import AsyncioTransport
-
-from rfxcom.protocol import RESET_PACKET, STATUS_PACKET
+from rfxcom.protocol import RESET_PACKET, MODE_PACKET, STATUS_PACKET
 
 
 class AsyncioTransportTestCase(TestCase):
 
-    def test_loop_once(self):
+    @mock.patch('asyncio.AbstractEventLoop')
+    @mock.patch('serial.Serial')
+    def test_transport_constructor(self, device, loop):
+        unit = AsyncioTransport(device, loop, callback=mock.Mock())
+        loop.add_writer.assert_called_once_with(device.fd, unit.setup)
 
-        loop = get_event_loop()
+    @mock.patch('asyncio.AbstractEventLoop')
+    @mock.patch('serial.Serial')
+    @mock.patch('rfxcom.transport.AsyncioTransport.write')
+    def test_transport_setup(self, unit_write, device, loop):
 
-        def handler(*args, **kwargs):
-            pass
+        unit = AsyncioTransport(device, loop, callback=mock.Mock())
+        unit.setup()
 
-        device = mock.MagicMock()
-
-        AsyncioTransport(device, loop, callback=handler)
-        loop._run_once()
-
-        device.write.assert_has_call(bytearray(RESET_PACKET))
-        device.write.assert_has_call(bytearray(STATUS_PACKET))
+        loop.remove_writer.assert_called_with(device.fd)
+        device.write.assert_called_once(RESET_PACKET)
+        loop.call_later.assert_any_call(mock.ANY,
+                                        super(AsyncioTransport, unit).write,
+                                        STATUS_PACKET)
+        unit_write.assert_called_once_with(MODE_PACKET)


### PR DESCRIPTION
unit tests still passes.

This is an interesting case where testing an object behaviour is tricky.
The unit test relied on the call to write() which happened, but at the wrong time.

I'm tempted to rewrite the unit tests for the transports, which are anyway quite empty :)

Having them written in a more complete way would have let you catch it earlier.
I might submit eventually something on the UT side ;)

Edit: I added also an improved UT, which checks the role removing any dependancy.
What's not done is checking that the calls to write() are done int the correct order, which seems to be quite important for the setup sequence, so it might be worth testing.
