### PR TITLE
Yield in setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 *.egg-info
 *.pyc
+*.swp
 .coverage
 .tox
 .vagrant
+.ropeproject
 dist
+tags
 docs/build/*

--- a/rfxcom/transport/base.py
+++ b/rfxcom/transport/base.py
@@ -3,7 +3,6 @@ rfxcom.transport.base
 =====================
 
 """
-
 from logging import getLogger
 
 from serial import Serial


### PR DESCRIPTION
Here's the change for having setup() a bit more readable.
Unfortunately I had to split setup() and _setup().

A coroutine is a generator, which means that needs something to yield from it to generate something.

Simply doing:
loop.call_later(setup)

def setup(self):
  yield from foo
  log(something)
  yield from bar

won't work, since when setup() is called back by the loop, will return a generator, which needs something to have it produce the results. The only way for the loop to have it done is to:
- have the generator yielded from by some other coroutine
- use Task (asyncio.async() in this case wraps around it)

In other terms, setup now removes itself as writer and then calls asynchronously _setup() which eventually will add the default writer, after having setup everything.

It should not be a problem, flow-wise, i find just uglier than I though, to have to split it.

_NOTE_ Please test it in a real HW env, before merging. I tested it on my env with a simple stub, which does not highlight any real HW problem.

Also, I updated some of the unittests you amended, for completeness:
- check that the callback is also called, after a read
- that in case of empty queue, no blocking write() is called
