### PR TITLE
Adding the possibility to add coroutines as callbacks for AsyncioTransport

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,6 +86,25 @@ receives. For example, see what it will `output for energy usage sensors`_.::
     finally:
         loop.close()
 
+You can also use a coroutine as callback for AsyncioTransport::
+
+    from asyncio import get_event_loop, coroutine
+    from rfxcom.transport import AsyncioTransport
+
+    dev_name = '/dev/serial/by-id/usb-RFXCOM_RFXtrx433_A1WYT9NA-if00-port0'
+    loop = get_event_loop()
+
+    @coroutine
+    def handler(packet):
+        print(packet)
+        yield from some_io()
+
+    try:
+        rfxcom = AsyncioTransport(dev_name, loop, callback=handler)
+        loop.run_forever()
+    finally:
+        loop.close()
+
 
 Contributing
 ------------

--- a/README.rst
+++ b/README.rst
@@ -97,7 +97,7 @@ You can also use a coroutine as callback for AsyncioTransport::
     @coroutine
     def handler(packet):
         print(packet)
-        yield from some_io()
+        yield from some_io(packet)
 
     try:
         rfxcom = AsyncioTransport(dev_name, loop, callback=handler)

--- a/rfxcom/protocol/temphumidity.py
+++ b/rfxcom/protocol/temphumidity.py
@@ -1,6 +1,6 @@
 """
-Temperture and Humidity sensors
-===============================
+Temperature and Humidity sensors
+================================
 
 """
 


### PR DESCRIPTION
Hi D0ugal,

For my project I needed to pass a coroutine as a callback to the AsyncioTransport. Currently you can't execute coros as callback. Could you please consider taking those changes in?

It's a great lib!

Cheers
Jonathan
